### PR TITLE
Pydle uses old tornado references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+Some issues with Pydle and tornado perhaps? tring some different requirements, I saw pydle was updated to grab a specific version of tornado....  so I'm trying this fork to play with my docker container.
+```
+Traceback (most recent call last):
+  File "/config/bot.py", line 6, in <module>
+    import manager
+  File "/config/manager.py", line 6, in <module>
+    import irc
+  File "/config/irc.py", line 4, in <module>
+    import pydle
+  File "/usr/lib/python3.5/site-packages/pydle/__init__.py", line 1, in <module>
+    from . import async, connection, protocol, client, features
+  File "/usr/lib/python3.5/site-packages/pydle/async.py", line 17, in <module>
+    class Future(tornado.concurrent.TracebackFuture):
+AttributeError: module 'tornado.concurrent' has no attribute 'TracebackFuture'
+```
+
+
 # sonarrAnnounced
 
 Python script to notify sonarr of tracker announcements from IRC announce channels. 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,3 @@
-Some issues with Pydle and tornado perhaps? tring some different requirements, I saw pydle was updated to grab a specific version of tornado....  so I'm trying this fork to play with my docker container.
-```
-Traceback (most recent call last):
-  File "/config/bot.py", line 6, in <module>
-    import manager
-  File "/config/manager.py", line 6, in <module>
-    import irc
-  File "/config/irc.py", line 4, in <module>
-    import pydle
-  File "/usr/lib/python3.5/site-packages/pydle/__init__.py", line 1, in <module>
-    from . import async, connection, protocol, client, features
-  File "/usr/lib/python3.5/site-packages/pydle/async.py", line 17, in <module>
-    class Future(tornado.concurrent.TracebackFuture):
-AttributeError: module 'tornado.concurrent' has no attribute 'TracebackFuture'
-```
-
-
 # sonarrAnnounced
 
 Python script to notify sonarr of tracker announcements from IRC announce channels. 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Flask_HTTPAuth==3.2.1
 pluginbase==0.5
 pony==0.7.1
 profig==0.4.1
-pydle==0.8.3
+pydle
 requests==2.12.4
 Unidecode==0.04.20
 pythreadworker==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ pony==0.7.1
 profig==0.4.1
 pydle
 requests==2.12.4
+tornado==4.5.3
 Unidecode==0.04.20
 pythreadworker==0.6.0


### PR DESCRIPTION
https://github.com/Shizmob/pydle/commit/9c5c4b87d3bb142bbff082bc9b1dfc1e4dd09a22

Basically Tornado is changing tornado.concurrent.TracebackFuture to just tornado.concurrent.Future from what I can tell.. Anyway grabbing Torando in the sonarrAnnounced requirements so we have the right version. This appears to have fixed my docker container as well...